### PR TITLE
Additional interface/empty struct test

### DIFF
--- a/interface_test.go
+++ b/interface_test.go
@@ -16,11 +16,12 @@ package goalesce
 
 import (
 	"errors"
+	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"reflect"
-	"testing"
 )
 
 func TestNewInterfaceCoalescer(t *testing.T) {
@@ -89,6 +90,12 @@ func Test_interfaceCoalescer_Coalesce(t *testing.T) {
 			"structs",
 			foo{Int: 1},
 			foo{Int: 0},
+			foo{Int: 1},
+		},
+		{
+			"structs and empty structs",
+			foo{Int: 1},
+			foo{},
 			foo{Int: 1},
 		},
 		{


### PR DESCRIPTION
Add test in `interface_test.go` to demonstrate that an empty struct will not override a populated one when boxed in an interface.